### PR TITLE
Fixing keydown events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+pnpm-lock.yaml

--- a/src/contenScript/contentScript.js
+++ b/src/contenScript/contentScript.js
@@ -214,6 +214,12 @@ const ContentScript = () => {
           {showNote && (
             <textarea
               style={textArea}
+              onKeyUp={(e) => {
+                e.stopPropagation()
+              }}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+              }}
               onChange={(e) => { 
                 e.stopPropagation()
                 setNote(e.target.value)}


### PR DESCRIPTION
Added keydown and keyup events listener where i am stopping event propogation in textarea element itself.

This fixes the bug of not being able to write note for a bookmark while watching a youtube video, because youtube itself adds keydown and keyup event listener to yt video player which is able to listen to those events and react accordingly thus losing focus of textarea element.